### PR TITLE
Removed adjustsLetterSpacingToFitWidth of UILabel.

### DIFF
--- a/Source/DVSwitch.m
+++ b/Source/DVSwitch.m
@@ -71,7 +71,6 @@
         label.text = string;
         label.font = self.font;
         label.adjustsFontSizeToFitWidth = YES;
-        label.adjustsLetterSpacingToFitWidth = YES;
         label.textAlignment = NSTextAlignmentCenter;
         label.textColor = self.labelTextColorOutsideSlider;
         [self.backgroundView addSubview:label];
@@ -95,7 +94,6 @@
         label.text = string;
         label.font = self.font;
         label.adjustsFontSizeToFitWidth = YES;
-        label.adjustsLetterSpacingToFitWidth = YES;
         label.textAlignment = NSTextAlignmentCenter;
         label.textColor = self.labelTextColorInsideSlider;
         [self.sliderView addSubview:label];


### PR DESCRIPTION
This was deprecated in iOS 7. If this is needed one can use the attributedString and adjust the NSKernAttributeName there.
